### PR TITLE
feature/SOF 7894 3

### DIFF
--- a/examples/job/get-file-from-job.ipynb
+++ b/examples/job/get-file-from-job.ipynb
@@ -123,7 +123,7 @@
    "outputs": [],
    "source": [
     "from mat3ra.notebooks_utils.api.settings import ENDPOINT_ARGS, ACCOUNT_ID\n",
-    "from mat3ra.notebooks_utils.job import wait_for_jobs_to_finish_async\n",
+    "from mat3ra.notebooks_utils.api.job import wait_for_jobs_to_finish_async\n",
     "from mat3ra.notebooks_utils.ipython.ui import display_JSON\n",
     "\n",
     "# Relevant functions from the API client\n",

--- a/examples/job/ml-train-model-predict-properties.ipynb
+++ b/examples/job/ml-train-model-predict-properties.ipynb
@@ -422,7 +422,7 @@
    },
    "outputs": [],
    "source": [
-    "from mat3ra.notebooks_utils.job import wait_for_jobs_to_finish_async\n",
+    "from mat3ra.notebooks_utils.api.job import wait_for_jobs_to_finish_async\n",
     "\n",
     "job_ids = [job[\"_id\"] for job in jobs]\n",
     "await wait_for_jobs_to_finish_async(job_endpoints, job_ids)"

--- a/src/py/mat3ra/notebooks_utils/api/job.py
+++ b/src/py/mat3ra/notebooks_utils/api/job.py
@@ -1,15 +1,47 @@
-from ..job import (
-    create_job,
-    get_convergence_series,
-    get_jobs_statuses_by_ids,
-    save_files,
-    submit_jobs,
-    wait_for_jobs_to_finish_async,
-)
+import datetime
+from collections import Counter
+from typing import List
+
+from mat3ra.api_client import JobEndpoints
+from mat3ra.utils.extra.tabulate import pretty_print
+
+from ..core.entity.job.api import create_job, get_jobs_statuses_by_ids, save_files, submit_jobs
+from ..pyodide.runtime import interruptible_polling_loop
+
+
+# Contains no external dependencies, only uses the API client,
+# so can be used in both regular Python and Pyodide environments.
+# In regular Python, the interruptible_polling_loop does not actually do anything,
+# so the function behaves like a normal polling loop.
+@interruptible_polling_loop()
+def wait_for_jobs_to_finish_async(endpoint: JobEndpoints, job_ids: List[str]) -> bool:
+    """
+    Waits for jobs to finish and prints their statuses.
+    A job is considered finished if it is not in "pre-submission", "submitted", or "active" status.
+
+    Args:
+        endpoint (JobEndpoints): Job endpoint object from the Exabyte API Client
+        job_ids (list): list of job IDs to wait for
+    """
+    statuses = get_jobs_statuses_by_ids(endpoint, job_ids)
+    counts = Counter(statuses)
+    headers = ["TIME", "SUBMITTED-JOBS", "ACTIVE-JOBS", "FINISHED-JOBS", "ERRORED-JOBS"]
+    now = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+    row = [
+        now,
+        counts.get("submitted", 0) + counts.get("queued", 0),
+        counts.get("active", 0),
+        counts.get("finished", 0),
+        counts.get("error", 0),
+    ]
+    pretty_print([row], headers, tablefmt="grid", stralign="center")
+
+    active_statuses = {"pre-submission", "submitted", "queued", "active"}
+    return not statuses or any(status in active_statuses for status in statuses)
+
 
 __all__ = [
     "create_job",
-    "get_convergence_series",
     "get_jobs_statuses_by_ids",
     "save_files",
     "submit_jobs",

--- a/src/py/mat3ra/notebooks_utils/job.py
+++ b/src/py/mat3ra/notebooks_utils/job.py
@@ -1,24 +1,11 @@
-import datetime
-from collections import Counter
 from functools import wraps
 from typing import Any, Callable, List
 
-from mat3ra.api_client import APIClient, JobEndpoints
-from mat3ra.utils.extra.tabulate import pretty_print
-
-try:
-    from mat3ra.made.material import Material
-except ImportError:
-    Material = None  # type: ignore[assignment,misc]
-
-try:
-    from mat3ra.wode import Workflow
-except ImportError:
-    Workflow = None  # type: ignore[assignment,misc]
+from mat3ra.api_client import APIClient
+from mat3ra.made.material import Material
+from mat3ra.wode import Workflow
 
 from .core.entity.job.api import create_job as _create_job
-from .core.entity.job.api import get_jobs_statuses_by_ids, save_files, submit_jobs
-from .pyodide.runtime import interruptible_polling_loop
 
 
 # TODO: place to mat3ra-made
@@ -70,40 +57,3 @@ def get_convergence_series(client: APIClient, job_id: str, subworkflow_index: in
     job_workflow = Workflow.create(finished_job["workflow"])
     subworkflow = job_workflow.subworkflows[subworkflow_index]
     return subworkflow.convergence_series(finished_job.get("scopeTrack"))
-
-
-@interruptible_polling_loop()
-def wait_for_jobs_to_finish_async(endpoint: JobEndpoints, job_ids: List[str]) -> bool:
-    """
-    Waits for jobs to finish and prints their statuses.
-    A job is considered finished if it is not in "pre-submission", "submitted", or "active" status.
-
-    Args:
-        endpoint (JobEndpoints): Job endpoint object from the Exabyte API Client
-        job_ids (list): list of job IDs to wait for
-    """
-    statuses = get_jobs_statuses_by_ids(endpoint, job_ids)
-    counts = Counter(statuses)
-    headers = ["TIME", "SUBMITTED-JOBS", "ACTIVE-JOBS", "FINISHED-JOBS", "ERRORED-JOBS"]
-    now = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
-    row = [
-        now,
-        counts.get("submitted", 0) + counts.get("queued", 0),
-        counts.get("active", 0),
-        counts.get("finished", 0),
-        counts.get("error", 0),
-    ]
-    pretty_print([row], headers, tablefmt="grid", stralign="center")
-
-    active_statuses = {"pre-submission", "submitted", "queued", "active"}
-    return not statuses or any(status in active_statuses for status in statuses)
-
-
-__all__ = [
-    "create_job",
-    "get_convergence_series",
-    "get_jobs_statuses_by_ids",
-    "save_files",
-    "submit_jobs",
-    "wait_for_jobs_to_finish_async",
-]


### PR DESCRIPTION
- **update: restructure job api**
- **update: import of job api**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized job utility imports. Job-related functions including `wait_for_jobs_to_finish_async`, `create_job`, and `submit_jobs` are now accessed from `mat3ra.notebooks_utils.api.job`. If you directly import these utilities, update your import statements to reference the new module path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Exabyte-io/api-examples/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->