### PR TITLE
fix: ELEMENTAL_TE_SOURCE was never applied to the submitted job

### DIFF
--- a/other/materials_designer/workflows/formation_energy.ipynb
+++ b/other/materials_designer/workflows/formation_energy.ipynb
@@ -457,8 +457,26 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Elemental total energy source: which owner's total_energy properties the\n",
+    "# job itself resolves at runtime, via the Resolve Total Energies for Elemental\n",
+    "# Materials subworkflow (index 2, same lookup cell 4.2 uses above). Must be\n",
+    "# patched here -- the cell 4.2 preview only reads properties for display, it\n",
+    "# does not affect the submitted job.\n",
+    "resolve_te_subworkflow = formation_workflow.subworkflows[2]\n",
+    "te_source_unit = resolve_te_subworkflow.get_unit_by_name(name=\"assign-source-of-te-for-an-element\")\n",
+    "te_source_unit.value = repr(ELEMENTAL_TE_SOURCE)\n",
+    "resolve_te_subworkflow.set_unit(te_source_unit)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
    "metadata": {},
    "source": [
     "### 5.4. Save workflow to collection\n"
@@ -467,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## 6. Create the compute configuration\n",
@@ -492,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +520,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "### 6.2. Create compute configuration\n"
@@ -511,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +546,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## 7. Create the Formation Energy job\n",
@@ -538,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### 7.2. Submit the Formation Energy job and monitor the status\n"
@@ -570,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +599,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## 8. Retrieve results\n",
@@ -602,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
## Problem
`formation_energy.ipynb`'s `ELEMENTAL_TE_SOURCE` parameter (cell 1.3) was only ever used in cell 4.2's client-side preview print. `formation_workflow` -- the object actually passed to `create_job` -- was never patched with it, so the `Resolve Total Energies for Elemental Materials` subworkflow always ran with its standata-hardcoded `'public'` value on the cluster, regardless of what the notebook parameter said. Preview and reality could silently disagree.

This was the source of intermittent formation_energy Cypress failures: `public` scope picks whichever account's total_energy for the same elemental structure currently has the highest recorded precision. Different accounts' default (unpinned) Total Energy jobs land on different auto-selected precision for the identical structure, so which one "wins" can permanently shift as new candidates enter the shared properties pool over time.

## Fix
Patch the workflow's own `assign-source-of-te-for-an-element` unit right after the workflow object is created, mirroring how `SCF_KGRID` already patches `pw_scf`.

## Verification
Confirmed locally end-to-end (local backend + a temporary Netlify preview of this branch): with this fix, plus pinning the elemental Si/Ge Total Energy jobs to an explicit k-grid in the Cypress test (a separate, already-existing gap in the test's Background), `formation_energy` for SiGe now resolves deterministically to `1.3642469947276368 eV/atom` -- matching the original calibration -- across repeated runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formation Energy workflows now use the selected elemental energy source when resolving elemental total energies at runtime.
  * Updated workflow configuration sequencing to ensure reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->